### PR TITLE
chore: longhorn update replicas count 

### DIFF
--- a/k3s/infra/longhorn/values.yaml
+++ b/k3s/infra/longhorn/values.yaml
@@ -1,3 +1,13 @@
+defaultSettings:
+  # -- Default number of replicas for volumes created using the Longhorn UI. For Kubernetes configuration, modify the `numberOfReplicas` field in the StorageClass. The default value is "{"v1":"3","v2":"3"}".
+  defaultReplicaCount: 2
+
+persistence:
+  # -- Reclaim policy that provides instructions for handling of a volume after its claim is released. (Options: "Retain", "Delete")
+  reclaimPolicy: Delete
+  # -- Replica count of the default Longhorn StorageClass.
+  defaultClassReplicaCount: 2
+
 preUpgradeChecker:
   # -- Setting that allows Longhorn to perform pre-upgrade checks. Disable this setting when installing Longhorn using Argo CD or other GitOps solutions.
   jobEnabled: false


### PR DESCRIPTION
Longhorn update replicas count to 2 from the default value, and specify the reclaim policy (Delete) default.