### PR TITLE
misc: remove logistics platform vm from ansible and terraform

### DIFF
--- a/ansible/inventory/vms_inventory.yaml
+++ b/ansible/inventory/vms_inventory.yaml
@@ -3,11 +3,6 @@ vms:
     logistics_platform:
     hardening_test:
 
-logistics_platform:
-  hosts:
-    logistics-platform-vm:
-      ansible_host: 192.168.10.240
-
 hardening_test:
   hosts:
     hardening-test-vm:

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -136,15 +136,5 @@ locals {
       tags      = ["terraform"]
       started   = false
     }
-
-    logistics-platform = {
-      id        = 420
-      cpu_cores = 4
-      memory    = 4096
-      size      = 50
-      ipv4      = "192.168.10.240/24"
-      hostname  = "logistics-platform"
-      tags      = ["terraform", "prod"]
-    }
   }
 }


### PR DESCRIPTION
Delete logistics platform VM from PVE, as it was deployed in Coolify.