### PR TITLE
Terraform/clean up

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -65,6 +65,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.8.0"
   hashes = [
+    "h1:3jWHVwO5QUIS9V1NsK10ZzdpkK2ABuB4G+UIWrVeGp4=",
     "h1:8z6L2Aa8lbZVxvUbQijo/Xz/5rVCGn5yXEjfSx00WHc=",
     "h1:KCuj8nPbNP/ofQrAoQIuQ3CP6k+ADpULvxr7dw2PrpM=",
     "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -16,7 +16,7 @@ locals {
       memory        = 1024
       ipv4          = "192.168.10.43/24"
       storage_size  = 20
-      startup_order = 5
+      startup_order = null
     }
 
     "netbox" = {
@@ -27,7 +27,7 @@ locals {
       memory        = 4096
       ipv4          = "192.168.10.48/24"
       storage_size  = 20
-      startup_order = 100
+      startup_order = null
     }
 
     "qbittorent" = {
@@ -38,7 +38,7 @@ locals {
       memory        = 1024
       ipv4          = "192.168.10.50/24"
       storage_size  = 20
-      startup_order = 100
+      startup_order = 4
     }
 
     "coolify" = {
@@ -49,7 +49,7 @@ locals {
       memory        = 8192
       ipv4          = "192.168.10.56/24"
       storage_size  = 100
-      startup_order = 20
+      startup_order = null
     }
 
   }

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,46 +1,10 @@
 locals {
   k3s_servers = {
-    # "k3s-server-10" = {
-    #   id        = 400
-    #   name      = "K3s-server-test-10"
-    #   cpu_cores = 2
-    #   memory    = 4096
-    #   ipv4      = "192.168.10.231/24"
-    #   hostname  = "k3s-server-test-10"
-    #   tags      = ["terraform", "cluster", "server"]
-    # }
-    # "k3s-server-20" = {
-    #   id        = 401
-    #   name      = "k3s-server-test-20"
-    #   cpu_cores = 2
-    #   memory    = 1024
-    #   ipv4      = "192.168.10.232/24"
-    #   hostname  = "k3s-server-test-20"
-    #   tags      = ["terraform", "cluster", "server"]
-    # }
+
   }
 
   k3s_agents = {
-    # "k3s-agent-10" = {
-    #   id        = 410
-    #   name      = "K3s-agent-test-10"
-    #   cpu_cores = 2
-    #   memory    = 1024
-    #   ipv4      = "192.168.10.233/24"
-    #   hostname  = "k3s-agent-10"
-    #   tags      = ["terraform", "cluster", "agent"]
-    #   igpu      = false
-    # }
-    # "k3s-agent-20" = {
-    #   id        = 411
-    #   name      = "K3s-agent-20"
-    #   cpu_cores = 2
-    #   memory    = 1024
-    #   ipv4      = "192.168.10.234/24"
-    #   hostname  = "k3s-agent-20"
-    #   tags      = ["terraform", "cluster", "agent"]
-    #   igpu      = false
-    # }
+
   }
 
   ubuntu_containers = {
@@ -53,19 +17,6 @@ locals {
       ipv4          = "192.168.10.43/24"
       storage_size  = 20
       startup_order = 5
-    }
-
-    "oracle-db" = {
-      id            = 104
-      hostname      = "oracle-db"
-      tags          = ["terraform"]
-      started       = false
-      start_on_boot = false
-      cpu_cores     = 2
-      memory        = 4096
-      ipv4          = "192.168.10.47/24"
-      storage_size  = 60
-      startup_order = null
     }
 
     "netbox" = {
@@ -88,28 +39,6 @@ locals {
       ipv4          = "192.168.10.50/24"
       storage_size  = 20
       startup_order = 100
-    }
-
-    "K3s-database" = {
-      id            = 108
-      hostname      = "k3s-database"
-      tags          = ["terraform", "cluster"]
-      cpu_cores     = 2
-      memory        = 4096
-      ipv4          = "192.168.10.44/24"
-      storage_size  = 40
-      startup_order = 2
-    }
-
-    "K3s-proxy" = {
-      id            = 109
-      hostname      = "k3s-proxy"
-      tags          = ["terraform", "cluster"]
-      cpu_cores     = 2
-      memory        = 1024
-      ipv4          = "192.168.10.45/24"
-      storage_size  = 8
-      startup_order = 2
     }
 
     "coolify" = {


### PR DESCRIPTION
### Changes
- Remove dead code from terraform `local.tf`
- Update start up order in LXCs (Ubuntu OS)
- Remove unused LXCs: oracle-db, k3s-test-proxy, k3s-test-database