### PR TITLE
chore: exclude all databases from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,13 @@
   "autoApprove": false,
   "packageRules": [
     {
-      "matchFileNames": ["k3s/apps/databases/**"],
+      "matchPackageNames": [
+        "postgres",
+        "mysql",
+        "mariadb",
+        "redis",
+        "bitnami/redis"
+      ],
       "enabled": false
     }
   ]


### PR DESCRIPTION
### Changes
**Excluded Databases (images) from Renovate:**
- postgres
- mariadb
- mysql
- redis
- bitnami/redis