### PR TITLE
fix(terraform): LXCs and VMs to ignore description lifecycle

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/bpg/proxmox" {
   version     = "0.111.1"
   constraints = "0.111.1"
   hashes = [
+    "h1:ML2D3UUZTM99yrll/EBXj7wBYMb8xmQgomqFNybEoxY=",
     "h1:jcqEv/zW+heFIPq5xwXxgS9EuBmbjIM1MriwQjx75WE=",
     "zh:18fb7c31a08dde6bffa1a4d4a211e604d6d17eec7092fd59331b3db3c6f3742c",
     "zh:1cd60761538289d4dd2a1086b3ae62a7b0bdd4b1a2f824e9a44e243413168dba",
@@ -63,6 +64,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/local" {
   version = "2.9.0"
   hashes = [
+    "h1:9rBZCMNpxKwMlRbWH2QpwD3kqUCAejdOZQ/aiiDObXQ=",
     "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
     "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
     "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",

--- a/terraform/k3s_agent_vm.tf
+++ b/terraform/k3s_agent_vm.tf
@@ -96,4 +96,10 @@ resource "proxmox_virtual_environment_vm" "k3s_agent_vm" {
     firewall = true
     model    = "virtio"
   }
+
+  lifecycle {
+    ignore_changes = [
+      description
+    ]
+  }
 }

--- a/terraform/k3s_server_vm.tf
+++ b/terraform/k3s_server_vm.tf
@@ -72,4 +72,10 @@ resource "proxmox_virtual_environment_vm" "k3s_server_vm" {
     firewall = true
     model    = "virtio"
   }
+
+  lifecycle {
+    ignore_changes = [
+      description
+    ]
+  }
 }

--- a/terraform/other_vm.tf
+++ b/terraform/other_vm.tf
@@ -72,4 +72,10 @@ resource "proxmox_virtual_environment_vm" "other_vm" {
     firewall = true
     model    = "virtio"
   }
+
+  lifecycle {
+    ignore_changes = [
+      description
+    ]
+  }
 }

--- a/terraform/ubuntu_lxc.tf
+++ b/terraform/ubuntu_lxc.tf
@@ -71,11 +71,13 @@ resource "proxmox_virtual_environment_container" "ubuntu_container" {
     }
   }
 
-  # Prevents recreation of containers when SSH keys changes
+
   lifecycle {
     ignore_changes = [
+      # Prevents recreation of containers when SSH keys changes
       initialization[0].user_account[0].keys,
-      mount_point
+      mount_point,
+      description
     ]
   }
 }


### PR DESCRIPTION
### Overview
Update LXCs and VMs resources to ignore description field on Terraform lifecycle after creation, allowing to manually add extra notes per resource from UI.