### PR TITLE
fix: configure gitleaks for false positive alerts

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -5,7 +5,7 @@ on:
   push:
   workflow_dispatch:
   schedule:
-    - cron: "0 4 * * *" # run once a day at 4 AM
+    - cron: "0 4 * * *" # run once a day at 4 AM (UTC)
 
 permissions:
   contents: read
@@ -22,3 +22,4 @@ jobs:
       - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: "8.30.1"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,8 +14,8 @@ useDefault = true
 # If a commit listed in the `commits` field below is encountered then that commit will be skipped and no
 # secrets will be detected for said commit. The same logic applies for regexes and paths.
 [[allowlists]]
-description = "Ignore example env files"
-paths = [ '''.*\.env\.example$''']
+description = "Ignore example files"
+paths = [ '''.*\.env\.example$''', '''.*\.ya?ml\.example$''']
 
 [[allowlists]]
 description = "Ignore Bitnami SealedSecrets"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,22 @@
+# Title for the gitleaks configuration file.
+title = "Custom Gitleaks configuration"
+
+# useDefault and path can NOT be used at the same time. Choose one.
+[extend]
+# useDefault will extend the default gitleaks config built in to the binary
+# the latest version is located at:
+# https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml
+useDefault = true
+
+# ⚠️ In v8.25.0 `[allowlist]` was replaced with `[[allowlists]]`.
+#
+# Global allowlists have a higher order of precedence than rule-specific allowlists.
+# If a commit listed in the `commits` field below is encountered then that commit will be skipped and no
+# secrets will be detected for said commit. The same logic applies for regexes and paths.
+[[allowlists]]
+description = "Ignore example env files"
+paths = [ '''.*\.env\.example$''']
+
+[[allowlists]]
+description = "Ignore Bitnami SealedSecrets"
+paths = ['''.*\.sealed\.ya?ml$''']


### PR DESCRIPTION
### Overview
Configure Git leaks to ignore `.env.example` & `sealedsecrets` files to fix false positive alerts on GitHub Actions. Pin Git leaks GitHub action to version `8.30.0` to fix version mismatch with Git leaks configuration file.